### PR TITLE
Remove empty content encoding

### DIFF
--- a/lib/fog/aws/storage.rb
+++ b/lib/fog/aws/storage.rb
@@ -564,11 +564,9 @@ module Fog
 
               if params[:headers]['Content-Encoding']
                 encoding = "aws-chunked, #{params[:headers]['Content-Encoding']}"
-              else
-                encoding = "aws-chunked, identity"
               end
 
-              params[:headers]['Content-Encoding']  = encoding
+              params[:headers]['Content-Encoding']  = encoding if encoding
             else
               params[:headers]['x-amz-content-sha256'] ||= Digest::SHA256.hexdigest(params[:body] || '')
             end

--- a/lib/fog/aws/version.rb
+++ b/lib/fog/aws/version.rb
@@ -1,5 +1,5 @@
 module Fog
   module AWS
-    VERSION = "0.1.2"
+    VERSION = "0.1.3"
   end
 end


### PR DESCRIPTION
This will help us fix the blank "Content-Encoding" file header in S3
